### PR TITLE
Update style to ensure images are displayed properly

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -63,6 +63,12 @@ header {
     width: 100%;
 }
 
+.content .img-container small {
+    color: #A5A5A5;
+    display: block;
+    text-align: center;
+}
+
 .sidebar {
   display: table-cell;
   width: 25%;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -59,6 +59,10 @@ header {
   padding: 0 20px 1em 20px;
 }
 
+.content img {
+    width: 100%;
+}
+
 .sidebar {
   display: table-cell;
   width: 25%;
@@ -196,7 +200,7 @@ article.summary > div {
 
 article.full .metadata,
 article.summary .metadata {
-  padding: 1%;  
+  padding: 1%;
   border: 1px dotted #EFEFEF;
   box-shadow: 0.1em 0.1em 0.1em #EFEFEF;
   font-style: italic;
@@ -246,7 +250,7 @@ ol.archive li .tags
 
 .social a {}
 
-.social i { 
+.social i {
   float: left;
   margin-right: 3px;
   padding-top: 4px;
@@ -308,4 +312,3 @@ li.tag-4 { font-size: 110%; margin: 0 1em; }
     margin: 0 4%;
   }
 }
-


### PR DESCRIPTION
This will ensure that images used will only take up 100% of the width of the content area, rather than overflowing.

This updated version of the theme is being used at http://crowdersoup.com/
