### PR TITLE
Fixed pages display

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -35,9 +35,9 @@
             <a href="{{ SITEURL }}/{{ FEED_ALL_RSS }}" rel="alternate"><img src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/images/icons/feed-32px.png" alt="rss feed"/></a>
           {% endif %}
 	    </div>
-	    {% if PAGES %}
+	    {% if DISPLAY_PAGES_ON_MENU %}
 	      <nav class="pages">
-	        {% for p in PAGES %}
+	        {% for p in pages %}
 			  <a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a>
 			  {% if not loop.last %}-{% endif %}
 			{% endfor %}


### PR DESCRIPTION
Not sure if this is a versioning issue, but `DISPLAY_PAGES_ON_MENU` is the boolean that determines if pages should be displayed at all and `pages`, the iterable, is now lowercase