### PR TITLE
Add striptags to article title to avoid html tags in page title

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ article.title }} - {{ SITENAME }}{% endblock %}
+{% block title %}{{ article.title|striptags }} - {{ SITENAME }}{% endblock %}
 
 {% block extra_meta %}
 


### PR DESCRIPTION
Hi,

I'm using your theme pelican-simplegrey and typografy. It seems that this also convert content of {{ article.title }}. As a result, the page's title shows html tags. 

Adding  `striptags` to {{ article.title }} resolves the issue.