### PR TITLE
Generate ``year'' field in footers

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -91,7 +91,7 @@
 
       <footer>
 		<p role="contentinfo">
-		  © 2013 {{ AUTHOR }} - Proudly powered by <a href="http://alexis.notmyidea.org/pelican/">pelican</a>. Theme <a href="https://github.com/fle/pelican-simplegrey">pelican-simplegrey</a>.
+		  © {{ dates[0].date|strftime('%Y') }} {{ AUTHOR }} - Proudly powered by <a href="http://alexis.notmyidea.org/pelican/">pelican</a>. Theme <a href="https://github.com/fle/pelican-simplegrey">pelican-simplegrey</a>.
     	</p>
 
 	  </footer>	

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ page.title }}- {{ SITENAME }}{% endblock %}
+{% block title %}{{ page.title }} - {{ SITENAME }}{% endblock %}
 
 {% block content %}
 


### PR DESCRIPTION
Generate the ``year'' field after the copyright icon based on the time of the last article.

Fix a minor typo in page.html.